### PR TITLE
Enumerate Docker runtimes for Intellij.

### DIFF
--- a/.idea/runConfigurations/Docker_Build.xml
+++ b/.idea/runConfigurations/Docker_Build.xml
@@ -1,0 +1,28 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Docker Build" type="docker-deploy" factoryName="dockerfile" server-name="Docker">
+    <deployment type="dockerfile">
+      <settings>
+        <option name="buildCliOptions" value="" />
+        <option name="buildOnly" value="true" />
+        <option name="command" value="" />
+        <option name="containerName" value="" />
+        <option name="entrypoint" value="" />
+        <option name="imageTag" value="b404.be:latest" />
+        <option name="portBindings">
+          <list>
+            <DockerPortBindingImpl>
+              <option name="containerPort" value="8080" />
+              <option name="hostIp" value="0.0.0.0" />
+              <option name="hostPort" value="8080" />
+            </DockerPortBindingImpl>
+          </list>
+        </option>
+        <option name="commandLineOptions" value="--rm " />
+        <option name="sourceFilePath" value="Dockerfile" />
+      </settings>
+    </deployment>
+    <method v="2">
+      <option name="Maven.BeforeRunTask" enabled="true" file="$PROJECT_DIR$/pom.xml" goal="compile package" />
+    </method>
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Docker_Build_and_Run.xml
+++ b/.idea/runConfigurations/Docker_Build_and_Run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Docker Build Image" type="docker-deploy" factoryName="dockerfile" server-name="Docker">
+  <configuration default="false" name="Docker Build and Run" type="docker-deploy" factoryName="dockerfile" server-name="Docker">
     <deployment type="dockerfile">
       <settings>
         <option name="buildCliOptions" value="" />


### PR DESCRIPTION
This creates two Docker runtimes for Intellij. 

1. Create the Docker image
2. Create the Docker image, but then run it after it has been built. 