### PR TITLE
deleteCompanyByName Fix

### DIFF
--- a/src/main/java/b404/businesslayer/CompanyBusiness.java
+++ b/src/main/java/b404/businesslayer/CompanyBusiness.java
@@ -209,9 +209,6 @@ public class CompanyBusiness {
 
             return "Successfully deleted company.";
         }
-        catch(NumberFormatException nfe){
-            throw new BadRequestException("CompanyID must be a valid integer");
-        }
         catch(SQLException sqle){
             throw new InternalServerErrorException(sqle.getMessage());
         }

--- a/src/main/java/b404/servicelayer/CompanyService.java
+++ b/src/main/java/b404/servicelayer/CompanyService.java
@@ -409,7 +409,7 @@ public class CompanyService {
             Authorization.isAdmin(jwt);
 
             //If no errors are thrown in the business layer, it was successful and OK response can be sent with message
-            return ResponseBuilder.buildSuccessResponse(companyBusiness.deleteCompanyByID(companyName));
+            return ResponseBuilder.buildSuccessResponse(companyBusiness.deleteCompanyByName(companyName));
         }
         //Catch all business logic related errors and return relevant response with message from error
         catch(BadRequestException bre){


### PR DESCRIPTION
According to Karnowsky, this endpoint does not work. I have confirmed that this endpoint did not work because it contained a copy paste error. This was also confirmed with this error in the application logs. This patch should provide a fix.  

```
today at 10:50 PM 03:50:46,448 WARN  [org.jboss.resteasy.resteasy_jaxrs.i18n] (default task-4) RESTEASY002142: Multiple resource methods match request "DELETE /company/id/5". Selecting one. Matching methods: [public javax.ws.rs.core.Response b404.servicelayer.CompanyService.deleteCompanyByID(java.lang.String,java.lang.String), public javax.ws.rs.core.Response b404.servicelayer.CompanyService.deleteCompanyByName(java.lang.String,java.lang.String)]
```